### PR TITLE
docs: replace CRA README with Freestyler project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,106 @@
-# Getting Started with Create React App
+# Freestyler
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Freestyler is a React + TypeScript playground for visually designing CSS layouts and component styles. You can create parent containers, add child elements, tweak style controls in real time, and export generated CSS for a single selected element or the full canvas.
 
-## Available Scripts
+## Features
 
-In the project directory, you can run:
+- **Visual CSS editor** for:
+  - Layout (`display`, `flex`, `grid`, alignment, columns)
+  - Sizing (`width`, `height`, `box-sizing`)
+  - Spacing (`margin`, `padding`) with axis/all sync toggles
+  - Borders (`width`, `style`, `radius`, `color`)
+  - Colors and shadows (multiple box shadows + text shadow)
+- **Multi-element canvas**:
+  - Add top-level preview items
+  - Add nested children (`div`, `p`, `h2`, `h3`)
+  - Reorder box shadow layers via drag-and-drop
+  - Select and delete items
+- **Export tools**:
+  - Export CSS for the active element
+  - Export CSS for all elements
+  - Copy exported CSS to clipboard
+- **Authoring helpers**:
+  - Toggle highlight for selected element
+  - Edit generated CSS ID
+  - Edit text content for typographic elements
 
-### `npm start`
+## Tech Stack
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+- **React 18** + **TypeScript**
+- **Create React App** (react-scripts)
+- **Sass** for styling
+- **@hello-pangea/dnd** for drag-and-drop interactions
+- **react-modal**, **react-colorful**, **react-switch**, **clipboard**
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+## Getting Started
 
-### `npm test`
+### Prerequisites
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+- **Node.js** 16+
+- **pnpm** (lockfile included), or npm/yarn if preferred
 
-### `npm run build`
+### Install dependencies
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Using pnpm:
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```bash
+pnpm install
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+Or with npm:
 
-### `npm run eject`
+```bash
+npm install
+```
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+### Run in development
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+```bash
+npm start
+```
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+Then open [http://localhost:3000](http://localhost:3000).
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+### Run tests
 
-## Learn More
+```bash
+npm test -- --watchAll=false
+```
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+### Create production build
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+```bash
+npm run build
+```
+
+## Project Structure
+
+```text
+src/
+  App.tsx                     # Main editor application and state orchestration
+  controls/
+    Input/                    # Reusable form controls (slider, select, checkbox, color picker)
+    InputGroups/              # Composite control groups (e.g., shadow controls)
+    MarginPadding/            # Sync controls for spacing
+    Modals/                   # CSS export modals
+    Button/                   # Button primitives
+    Preview.tsx               # Preview models + rendered preview component
+    PreviewList.tsx           # Item tree/list for selecting preview elements
+  properties/                 # Enums/types for CSS properties and model state
+  styles/                     # App, layout, modal, and utility styles
+```
+
+## How CSS Export Works
+
+Freestyler serializes the current preview model into CSS declarations (including layout-specific declarations for flex/grid) and emits rules scoped by each element's `#cssId`. Export can be done per-element or across all items in the canvas.
+
+## Scripts
+
+- `npm start` – start development server
+- `npm test` – run test runner
+- `npm run build` – build production bundle
+- `npm run eject` – eject CRA configuration (irreversible)
+
+---
+
+If you want, I can also add a quick **"Usage walkthrough"** section with screenshots and a step-by-step flow for creating/exporting a layout.


### PR DESCRIPTION
### Motivation
- Replace the generic Create React App README with a project-specific guide that explains the app purpose and developer workflows.
- Provide quick onboarding for contributors by documenting features, tech stack, and common tasks like running and testing the app.

### Description
- Replaced the default CRA README content with a new `README.md` describing Freestyler as a visual CSS playground and authoring tool.
- Added a Features section that summarizes layout, sizing, spacing, borders, colors/shadows, multi-element canvas, export options, and authoring helpers.
- Documented the tech stack, prerequisites, install commands (`pnpm install` / `npm install`), development start (`npm start`), test (`npm test -- --watchAll=false`) and build (`npm run build`) workflows.
- Included a Project Structure overview and an explanation of how CSS export is generated from the preview model.

### Testing
- Ran `pnpm install` to validate dependency resolution and it completed successfully. 
- Ran unit tests with `npm test -- --watchAll=false` and the test suite passed (1 test, 1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8afb313c83239bf2c1fed60162c4)